### PR TITLE
Fix Components V2: Remove content field when sending LayoutView

### DIFF
--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -565,7 +565,6 @@ class SanctionAppealTypeView(ui.View):
         # Show dropdown menu of cases
         view = CaseSelectView(self.user, cases, "user")
         await interaction.followup.send(
-            f"{EMOJIS['ticket']} **Case Selection**\nPlease select the case you wish to appeal:",
             view=view,
             ephemeral=True
         )
@@ -597,7 +596,6 @@ class SanctionAppealTypeView(ui.View):
         # Show dropdown menu of cases
         view = CaseSelectView(self.user, cases, "server", invite_link=invite)
         await interaction.followup.send(
-            f"{EMOJIS['ticket']} **Case Selection**\nPlease select the case you wish to appeal:",
             view=view,
             ephemeral=True
         )
@@ -794,7 +792,6 @@ class SupportPanelView(ui.View):
         # Show dropdown menu to choose request type
         view = LegalRequestTypeView(interaction.user)
         await interaction.response.send_message(
-            f"{EMOJIS['ticket']} **Creating ticket - Legal Request**",
             view=view,
             ephemeral=True
         )


### PR DESCRIPTION
When using Components V2 (LayoutView), the 'content' field cannot be used. All text must be inside TextDisplay within the Container.

Fixed:
- CaseSelectView (2 occurrences) - removed content from followup.send()
- LegalRequestTypeView - removed content from send_message()

Text is already present in TextDisplay inside each view's Container.